### PR TITLE
Updates Client to create Bunny::Consumer with queue obj, not string

### DIFF
--- a/lib/bunny_burrow/client.rb
+++ b/lib/bunny_burrow/client.rb
@@ -24,7 +24,9 @@ module BunnyBurrow
         persistence: false
       }
 
-      consumer = Bunny::Consumer.new(channel, DIRECT_REPLY_TO, SecureRandom.uuid)
+      queue = channel.queue(SecureRandom.uuid)
+
+      consumer = Bunny::Consumer.new(channel, DIRECT_REPLY_TO, queue)
       consumer.on_delivery do |_, _, received_payload|
         result = handle_delivery(details, received_payload)
       end

--- a/spec/lib/bunny_burrow/client_spec.rb
+++ b/spec/lib/bunny_burrow/client_spec.rb
@@ -28,11 +28,13 @@ describe BunnyBurrow::Client do
     let(:routing_key)    { 'routing.key' }
     let(:payload)        { 'payload' }
     let(:topic_exchange) { double 'topic exchange' }
+    let(:queue)          { double Bunny::Queue }
 
     before(:each) do
       allow(Bunny::Consumer).to receive(:new).and_return(consumer)
       allow(channel).to receive(:topic).and_return(topic_exchange)
       allow(channel).to receive(:basic_consume_with)
+      allow(channel).to receive(:queue).and_return(queue)
       allow(consumer).to receive(:on_delivery)
       allow(subject).to receive(:log)
       allow(topic_exchange).to receive(:publish)
@@ -92,7 +94,7 @@ describe BunnyBurrow::Client do
       end
 
       it 'creates a consumer to consume the reply-to pseudo-queue' do
-        expect(Bunny::Consumer).to receive(:new).with(channel, BunnyBurrow::Client::DIRECT_REPLY_TO, an_instance_of(String))
+        expect(Bunny::Consumer).to receive(:new).with(channel, BunnyBurrow::Client::DIRECT_REPLY_TO, queue)
         subject.publish request, routing_key
       end
 
@@ -162,4 +164,3 @@ describe BunnyBurrow::Client do
     end
   end # describe '#shutdown'
 end # describe BunnyBurrow::Client
-


### PR DESCRIPTION
This change should not result in any change in functionality.

The motivation behind introducing this change is two-fold:

1. The official Bunny documentation shows multiple examples where a Bunny::Consumer object is initialized with a Bunny::Queue object as the queue parameter, and none where the queue parameter is a string literal. Although the string parameter is documented and supported by the bunny gem, the examples given and community usage seems to show a preference for passing a Queue object.
2. The OpenTelemetry bunny instrumentation gem is currently incompatible with the current version of bunny_burrow. The OTel gem works by patching a number of methods in Bunny classes, and expects to be able to call `queue.channel` inside its patch of `Bunny::Consumer#call`. This results in a runtime error with the current versions of bunny_burrow and the OTel gem. See https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/bunny/lib/opentelemetry/instrumentation/bunny/patches/consumer.rb#L14

Regarding point 2 above, I acknowledge that the "better" course of action would probably be to file a bug report with the OTel bunny instrumentation gem. In my opinion, the authors of the gem made an incorrect assumption about the underlying Bunny gem that contradicts the latter's own documentation.

That said, I don't believe there's any harm in making this change to bunny_burrow AND it is the quicker option. Since this issue is currently a blocker to being able to use the OTel bunny instrumentation gem with a project that uses bunny_burrow, I decided to propose this fix.